### PR TITLE
Converted System Column Names to UPPER_CASE

### DIFF
--- a/tap_mssql/__init__.py
+++ b/tap_mssql/__init__.py
@@ -185,7 +185,7 @@ def discover_catalog(mssql_conn, config):
     else:
         table_schema_clause = """
         WHERE c.table_schema NOT IN (
-        'information_schema',
+        'INFORMATION_SCHEMA',
         'performance_schema',
         'sys'
         )"""
@@ -197,7 +197,7 @@ def discover_catalog(mssql_conn, config):
             """SELECT table_schema,
                 table_name,
                 table_type
-            FROM information_schema.tables c
+            FROM INFORMATION_SCHEMA.tables c
             {}
         """.format(
                 table_schema_clause
@@ -217,9 +217,9 @@ def discover_catalog(mssql_conn, config):
                 , c.table_name
                 , c.column_name
 
-                from information_schema.constraint_column_usage c
+                from INFORMATION_SCHEMA.CONSTRAINT_COLUMN_USAGE c
 
-                join information_schema.table_constraints tc
+                join INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc
                         on tc.table_schema = c.table_schema
                         and tc.table_name = c.table_name
                         and tc.constraint_name = c.constraint_name
@@ -232,7 +232,7 @@ def discover_catalog(mssql_conn, config):
                     numeric_precision,
                     numeric_scale,
                     case when cc.column_name is null then 0 else 1 end
-                FROM information_schema.columns c
+                FROM INFORMATION_SCHEMA.columns c
 
                 left join constraint_columns cc
                     on cc.table_name = c.table_name


### PR DESCRIPTION
SELECT'ing from lower_case information_schema and similar system tables does not work in different collations. Changed to UPPER_CASE.